### PR TITLE
Fix status navigation

### DIFF
--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/navigation/AppNavigation.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/navigation/AppNavigation.kt
@@ -29,8 +29,7 @@ fun AppNavigation() {
     val startDestination = if (tokenManager.hasSession()) Screen.Home.route else Screen.SessionChecker.route
 
     val productResultArgs = ProductResultArgs.entries.toTypedArray()
-
-
+    
     NavHost(navController, startDestination = startDestination) {
         composable(Screen.Login.route) {
             LoginScreen(navController)

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/navigation/AppNavigation.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/navigation/AppNavigation.kt
@@ -26,10 +26,12 @@ import ar.edu.utn.frba.inventario.utils.withArgsDefinition
 fun AppNavigation() {
     val navController = rememberNavController()
     val tokenManager = rememberTokenManager()
+    val startDestination = if (tokenManager.hasSession()) Screen.Home.route else Screen.SessionChecker.route
 
     val productResultArgs = ProductResultArgs.entries.toTypedArray()
 
-    NavHost(navController, startDestination = Screen.SessionChecker.route) {
+
+    NavHost(navController, startDestination = startDestination) {
         composable(Screen.Login.route) {
             LoginScreen(navController)
         }

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/OrdersScreen.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/OrdersScreen.kt
@@ -1,6 +1,6 @@
 package ar.edu.utn.frba.inventario.screens
 
-import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,7 +32,6 @@ import ar.edu.utn.frba.inventario.utils.Screen
 import ar.edu.utn.frba.inventario.viewmodels.OrdersViewModel
 
 
-@SuppressLint("UnrememberedGetBackStackEntry")
 @Composable
 fun OrdersScreen(
     navController: NavController,
@@ -67,6 +66,15 @@ fun OrdersScreen(
                 viewModel.getFilteredItems(),
                 Modifier.weight(1f)
             )
+            BackHandler {
+                navController.navigate(Screen.Home.route) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        saveState = true
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
         }
     }
 }

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/SessionCheckerScreen.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/SessionCheckerScreen.kt
@@ -19,12 +19,7 @@ fun SessionCheckerScreen(
     tokenManager: TokenManager
 ) {
     LaunchedEffect(Unit) {
-        if (tokenManager.hasSession()) {
-            Log.d("SessionCheckerScreen", "Session found, navigating to Home")
-            navController.navigate(Screen.Home.route) {
-                popUpTo(Screen.SessionChecker.route) { inclusive = true }
-            }
-        } else {
+        if (!tokenManager.hasSession()) {
             Log.d("SessionCheckerScreen", "No session found, navigating to Login")
             navController.navigate(Screen.Login.route) {
                 popUpTo(Screen.SessionChecker.route) { inclusive = true }


### PR DESCRIPTION
Se aplican los siguientes cambios y comportamientos al navegar:
1. Clickeando la bottom navigation bar se mantienen los estados filtrados
2. Desde alguna screen que no sea home, al clickear "back" regresa a home directamente sin pasar por cada una de las pantallas navegadas (así estaba funcionando antes del cambio)
3. Al regresar a home y volver a orders, continúa manteniendo los filtros aplicados