### PR TITLE
Se agrega pantalla de detalles de un pedido

### DIFF
--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/navigation/AppNavigation.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/navigation/AppNavigation.kt
@@ -15,6 +15,7 @@ import androidx.navigation.navArgument
 import ar.edu.utn.frba.inventario.api.utils.TokenManager
 import ar.edu.utn.frba.inventario.screens.HomeScreen
 import ar.edu.utn.frba.inventario.screens.LoginScreen
+import ar.edu.utn.frba.inventario.screens.OrderDetailScreen
 import ar.edu.utn.frba.inventario.screens.OrdersScreen
 import ar.edu.utn.frba.inventario.screens.ShipmentScreen
 import ar.edu.utn.frba.inventario.screens.UserScreen
@@ -74,6 +75,15 @@ fun AppNavigation(navController: NavHostController) {
         )) { backStackEntry->
             val idShipment = backStackEntry.arguments?.getString("id")?:""
             ShipmentScreen(navController = navController, id = idShipment)
+        }
+        composable(route=Screen.OrderDetail.route+"/{orderId}",
+            arguments = listOf(
+                navArgument(name = "orderId"){
+                    type= NavType.StringType
+                }
+            )) { backStackEntry->
+            val idOrder = backStackEntry.arguments?.getString("orderId")?:""
+            OrderDetailScreen(navController = navController, id = idOrder)
         }
     }
 }

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/OrderDetailScreen.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/OrderDetailScreen.kt
@@ -1,0 +1,125 @@
+package ar.edu.utn.frba.inventario.screens
+
+import android.annotation.SuppressLint
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import ar.edu.utn.frba.inventario.api.model.product.Product
+import ar.edu.utn.frba.inventario.utils.Screen
+import ar.edu.utn.frba.inventario.viewmodels.OrderDetailViewModel
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun OrderDetailScreen(viewModel:OrderDetailViewModel = hiltViewModel(), navController: NavController, id:String){
+    Scaffold {
+            innerPadding ->
+        OrderDetailBodyContent(viewModel, navController, id,innerPadding)
+    }
+
+}
+@Composable
+fun OrderDetailBodyContent(viewModel:OrderDetailViewModel, navController: NavController, id:String, innerPadding: PaddingValues){
+    viewModel.loadOrder(id)
+    val order by viewModel.order.collectAsState()
+
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .background(MaterialTheme.colorScheme.secondaryContainer)
+        .padding(innerPadding)
+    ) {
+        Button(onClick = {navController.navigate(Screen.Home.route)}
+        ){
+            Text(text = "Atras", style = MaterialTheme.typography.titleMedium)
+        }
+        Spacer(modifier = Modifier
+            .height(10.dp))
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.primaryContainer)){
+            Column (modifier = Modifier
+                .padding(20.dp)){
+                Text(
+                    text = "Pedido ${order.number}",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontSize = 25.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(text = "Remitente: ${order.sender}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(text = "Total de productos unicos: ${order.products.size}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            }
+        }
+        LazyColumn(modifier = Modifier
+            .padding(15.dp)) {
+            items(order.products){
+                    product ->
+                ProductItem(product)
+                Spacer(modifier = Modifier.height(5.dp))
+            }
+        }
+        Spacer(modifier = Modifier
+            .height(10.dp))
+    }
+}
+
+@Composable
+fun ProductItem(product:Product){
+    ElevatedCard(colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ,modifier = Modifier
+            .fillMaxSize()
+            .padding(2.dp)){
+        Row(modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 10.dp)){
+            Box(modifier = Modifier
+                .weight(2f)
+                .padding(15.dp)){
+                Text(text = product.name, fontWeight = FontWeight.Bold, fontSize = 20.sp, style = MaterialTheme.typography.bodyMedium)
+            }
+            Spacer(modifier = Modifier
+                .height(10.dp))
+            Box(modifier = Modifier
+                .weight(1f)
+                .padding(15.dp)) {
+                Text(text = "Cantidad ${product.quantity}", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun vistaPedidoFinal(){
+    OrderDetailScreen(navController = rememberNavController(), id = "ORD-003")
+}
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun vistaPedidoFinalDark(){
+    OrderDetailScreen(navController = rememberNavController(), id = "ORD-003")
+}

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/utils/Screen.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/utils/Screen.kt
@@ -8,6 +8,7 @@ enum class Screen(val route: String) {
     Orders("orders"),
     User("user"),
     Shipment("shipment"),
+    OrderDetail("orderdetail"),
     Scan("scan"),
     ProductResult("product_result"),
     ManualCode("manual_code");

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/viewmodels/OrderDetailViewModel.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/viewmodels/OrderDetailViewModel.kt
@@ -1,0 +1,228 @@
+package ar.edu.utn.frba.inventario.viewmodels
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ar.edu.utn.frba.inventario.api.model.item.ItemStatus
+import ar.edu.utn.frba.inventario.api.model.order.Order
+import ar.edu.utn.frba.inventario.api.model.product.Product
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderDetailViewModel @Inject constructor(): ViewModel(){
+
+    private val _order  = MutableStateFlow<Order>(Order(id = "0", number = "", sender = "", status = ItemStatus.PENDING, products = emptyList()))
+    val order = _order.asStateFlow()
+
+
+    fun loadOrder(id:String){
+        viewModelScope.launch {
+
+            Log.d("OrderDetailViewModel", "Iniciando pedido a API del pedido: $id")
+            val response = OrderRepositoryMock(id)
+
+            val result = 200
+
+            when(result){
+                200 -> {
+                    _order.value = response
+                    Log.d("ShipmentViewModel", "Exito en carga de datos del pedido: $id")
+                }
+                400 -> {
+                    Log.d("ShipmentViewModel", "Fallo la carga de datos del pedido: $id")
+                }
+            }
+        }
+    }
+
+    //Para pruebas, hasta que este el endponit
+    private fun OrderRepositoryMock(id: String):Order{
+        val orders: List<Order> =
+            listOf(
+                Order(
+                    id = "ORD-001",
+                    number = "P-9090",
+                    sender = "Cliente Premium",
+                    status = ItemStatus.PENDING,
+                    products = listOf(
+                        Product("P-101", "Producto A", 2),
+                        Product("P-102", "Producto B", 3)
+                    ),
+                    estimatedReceiptDate = LocalDateTime.now().plusDays(2)
+                ),
+                Order(
+                    id = "ORD-002",
+                    number = "P-9091",
+                    sender = "Cliente Regular",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-201", "Producto C", 5)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().plusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-004",
+                    number = "P-9095",
+                    sender = "Cliente Prueba",
+                    status = ItemStatus.CANCELLED,
+                    products = listOf(
+                        Product("P-401", "Producto F", 4)
+                    ),
+                    cancellationDate = LocalDateTime.now().minusHours(3)
+                ),
+                Order(
+                    id = "ORD-005",
+                    number = "P-9099",
+                    sender = "Empresa X",
+                    status = ItemStatus.CANCELLED,
+                    products = List(15) { index ->
+                        Product("P-50${index+1}", "Producto ${index+1}", index+1)
+                    },
+                    cancellationDate = LocalDateTime.now().plusDays(3)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+                Order(
+                    id = "ORD-003",
+                    number = "P-9092",
+                    sender = "Cliente VIP",
+                    status = ItemStatus.COMPLETED,
+                    products = listOf(
+                        Product("P-301", "Producto D", 1),
+                        Product("P-302", "Producto E", 2)
+                    ),
+                    confirmedReceiptDate = LocalDateTime.now().minusDays(1)
+                ),
+            )
+
+
+        val result = orders.first { s -> s.id.equals(id) }
+
+        return result
+    }
+}
+


### PR DESCRIPTION
Se añade una vista basica de los detalles de un pedido(Order).
Despues talvez hay que hacer un cambio en el componente CardItem, que lo usa tanto la pantalla de Home como la de Orders. Para que el onclick pueda direccionar bien a la pantalla de detalles de un envio o a la pantalla detalles de un pedido. 
![Captura de pantalla 2025-05-31 184443](https://github.com/user-attachments/assets/cac6b9e9-32a5-4900-a14b-d05e2df26b1f)![Captura de pantalla 2025-05-31 184548](https://github.com/user-attachments/assets/a7dc1dac-3c57-4f15-a8aa-73e072858218)
