### PR TITLE
Bloqueo boton scan

### DIFF
--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/shipment/ShipmentDetailScreen.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/shipment/ShipmentDetailScreen.kt
@@ -324,6 +324,7 @@ fun ButtonBox(viewModel: ShipmentDetailViewModel, navController: NavController) 
 
                     Button(
                         colors = ButtonDefaults.buttonColors(MaterialTheme.colorScheme.primary),
+                        enabled = !viewModel.isStateCompleteShipment.value || viewModel.selectedShipment.value.status!=ItemStatus.COMPLETED,
                         onClick = {
 
                             coroutineScope.launch {

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/shipment/ShipmentDetailScreen.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/screens/shipment/ShipmentDetailScreen.kt
@@ -95,7 +95,7 @@ fun ShipmentDetailScreen(
                 ) {
                     IconButton(
                         onClick = {
-                            if(viewModel.selectedShipment.value.status == ItemStatus.COMPLETED){
+                            if(viewModel.selectedShipment.value.status == ItemStatus.COMPLETED || viewModel.selectedShipment.value.status == ItemStatus.BLOCKED || !viewModel.ExistProductWithLoadedQuantityUpdated()){
                                 navController.navigate(Screen.Shipments.route)
                             }else{
                                 viewModel.showExitConfirmation()
@@ -324,7 +324,7 @@ fun ButtonBox(viewModel: ShipmentDetailViewModel, navController: NavController) 
 
                     Button(
                         colors = ButtonDefaults.buttonColors(MaterialTheme.colorScheme.primary),
-                        enabled = !viewModel.isStateCompleteShipment.value || viewModel.selectedShipment.value.status!=ItemStatus.COMPLETED,
+                        enabled = !viewModel.isStateCompleteShipment.value,
                         onClick = {
 
                             coroutineScope.launch {

--- a/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/viewmodels/ShipmentsViewModel.kt
+++ b/InventarioApp/app/src/main/java/ar/edu/utn/frba/inventario/viewmodels/ShipmentsViewModel.kt
@@ -47,7 +47,7 @@ class ShipmentsViewModel @Inject constructor(
     val error: StateFlow<String?> = _error.asStateFlow()
 
     fun getShipments() {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch(Dispatchers.IO) {
             _loading.value = true
             _error.value = null
 


### PR DESCRIPTION
Se deshabilita boton Scan en shipmentDetail, si se tiene todos los productos cargados.
Se muestra mensaje al salir de shipmentDetail, solo si se tiene algun producto cargado.